### PR TITLE
Allow unload event to be configured

### DIFF
--- a/src/js/o-audio.js
+++ b/src/js/o-audio.js
@@ -13,13 +13,14 @@ class OAudio {
 		}
 		this.oAudioEl = oAudioEl;
 		this.options = Object.assign({}, {
+			unloadEventName: 'onbeforeunload' in window ? 'beforeunload' : 'unload'
 		}, opts || OAudio.getDataAttributes(oAudioEl));
 
 		this.tracking = new Tracking(oAudioEl, this.options);
 
-		if (this.options.dispatchListenedEventOnUnload !== undefined) {
+		if (this.options.unloadEventName) {
 			window.addEventListener(
-				'onbeforeunload' in window ? 'beforeunload' : 'unload',
+				this.options.unloadEventName,
 				() => this.tracking.dispatchListenedEvent()
 			);
 		}

--- a/test/oAudio.test.js
+++ b/test/oAudio.test.js
@@ -68,14 +68,12 @@ describe("OAudio", () => {
 			proclaim.equal(action, "listened");
 		});
 
-		it('when the page unloads', () => {
+		it('when a given event on the window is fired', () => {
 			const events = oTracking.start();
 			new OAudio(stubAudioEl, {
-				dispatchListenedEventOnUnload: true
+				unloadEventName: 'unload-event'
 			});
-
-			const unloadEventName = 'onbeforeunload' in window ? 'beforeunload' : 'unload';
-			window.dispatchEvent(new Event(unloadEventName));
+			window.dispatchEvent(new Event('unload-event'));
 			proclaim.lengthEquals(events, 1);
 			const { action } = events[0];
 			proclaim.equal(action, "listened");


### PR DESCRIPTION
- Helpful for tests
- Allows the listener to be disabled by passing throw a falsy value, like so:

```
<audio controls data-o-component="o-audio" data-unload-event-name="">
	<source
		src="https://media.acast.com/ftnewsbriefing/wednesday-november14/media.mp3"
		type="audio/mpeg" />
</audio>
```
