### PR TITLE
Debounce instead of throttle

### DIFF
--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -2,6 +2,15 @@
 import './../../main.js';
 
 function initDemos() {
+
+	document.addEventListener('oTracking.event', ({detail}) => {
+		console.log(
+			`%cReceived oTracking ${detail.category} event %c${detail.action}`,
+			'color: green','color: blue',
+			detail
+		);
+	});
+
 	document.addEventListener('DOMContentLoaded', function() {
 		document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
 	});

--- a/demos/src/native.mustache
+++ b/demos/src/native.mustache
@@ -1,7 +1,11 @@
 <div>
-	<audio controls data-o-component="o-audio">
+	<audio
+		controls
+		data-o-component="o-audio"
+		data-dispatch-listened-event-on-unload>
 		<source
 			src="https://media.acast.com/ftnewsbriefing/wednesday-november14/media.mp3"
 			type="audio/mpeg" />
 	</audio>
+	<p>oTracking events will be shown in the JS console</p>
 </div>

--- a/src/js/tracking.js
+++ b/src/js/tracking.js
@@ -32,7 +32,7 @@ function getProgressPoint(progress) {
 const EVENTS = [
 	{ name: 'playing' },
 	{ name: 'pause' },
-	{ name: 'seeked', throttle: 1000 },
+	{ name: 'seeked', debounceEvery: 1000 },
 	{ name: 'timeupdate' },
 	{ name: 'ended' },
 	{ name: 'error' },
@@ -75,10 +75,10 @@ class AudioTracking {
 	}
 
 	attachListeners() {
-		EVENTS.forEach(({ name, throttle }) => {
+		EVENTS.forEach(({ name, debounceEvery }) => {
 			let listener = this.eventListener.bind(this);
-			if (throttle) {
-				listener = Utils.throttle(listener, throttle);
+			if (debounceEvery) {
+				listener = Utils.debounce(listener, debounceEvery);
 			}
 			this.delegate.on(name, listener);
 		});

--- a/test/tracking.test.js
+++ b/test/tracking.test.js
@@ -35,7 +35,7 @@ describe('Tracking' , () => {
 			})
 		);
 
-		it('emits the seeked event once every second', () => {
+		it('prevents the `seeked` event from spamming (when the seek bar is used)', () => {
 			const clock = sinon.useFakeTimers();
 			const events = oTracking.start();
 			const stubAudioEl = initAudioElement();


### PR DESCRIPTION
`seeked` gets fired _alot_ by the HTML5 audio element (when the seek bar is dragged).

Originally this was addressed by throttling, which will send a `seeked` event every second while the user drags the seek bar. In reality we only need to know that they performed a seek, so debouncing is more appropriate.