### PR TITLE
Export Tracking in main.js , so it's exposed in the bundle

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
 import oAudio from './src/js/o-audio';
+import Tracking from './src/js/tracking';
 
 const constructAll = function () {
 	oAudio.init();
@@ -8,3 +9,5 @@ const constructAll = function () {
 document.addEventListener('o.DOMContentLoaded', constructAll);
 
 export default oAudio;
+
+export { Tracking };

--- a/src/js/o-audio.js
+++ b/src/js/o-audio.js
@@ -100,5 +100,3 @@ class OAudio {
 }
 
 export default OAudio;
-
-export { Tracking };


### PR DESCRIPTION
The approach I look in the previous PR didn't work https://github.com/Financial-Times/o-audio/pull/13

On closer inspection, anything that needs to be available outside of the bundle needs to be exported from main.js