### PR TITLE
Allow root_id to be set externally

### DIFF
--- a/src/js/tracking.js
+++ b/src/js/tracking.js
@@ -46,7 +46,8 @@ const EVENTS = [
 const TRACKING_ATTRIBUTES = [
 	'contentId',
 	'audioSubtype',
-	'playerType'
+	'playerType',
+	'root_id',
 ];
 
 function whitelistProps(props) {


### PR DESCRIPTION
The new persistent player in the app requires root_id to be fixed across multiple page views.