### PR TITLE
Add error property in event.detail

### DIFF
--- a/src/js/tracking.js
+++ b/src/js/tracking.js
@@ -2,11 +2,19 @@ import Delegate from 'ftdomdelegate';
 import * as Utils from 'o-utils';
 
 function fireEvent(action, audioObject, extraDetail = {}) {
+	const error = audioObject.audio.error ? {
+		code: audioObject.audio.error.code,
+		message: audioObject.audio.error.message,
+		currentTime: audioObject.audio.currentTime,
+		src: audioObject.audio.currentSrc
+	} : undefined;
+
 	const event = new CustomEvent('oTracking.event', {
 		detail: Object.assign({
 			category: 'audio',
 			action,
 			duration: audioObject.audioLength,
+			error,
 		}, audioObject.trackingProperties, extraDetail),
 		bubbles: true,
 	});

--- a/test/tracking.test.js
+++ b/test/tracking.test.js
@@ -99,6 +99,37 @@ describe('Tracking' , () => {
 				contentId
 			});
 		});
+
+		it('sets error property on events if audio element has an error prorperty', () => {
+			const events = oTracking.start();
+			const stubAudioEl = initAudioElementWithMetadata();
+			const error = {
+				code: 4,
+				message: 'MEDIA_ELEMENT_ERROR: Empty src attribute',
+			};
+
+			initTracking(stubAudioEl, { contentId });
+			mockMetadata(stubAudioEl);
+
+
+			stubAudioEl.currentTime = 18;
+			stubAudioEl.error = error;
+			stubAudioEl.dispatchEvent(new Event('error'));
+
+			proclaim.deepEqual(events[0], {
+				category: 'audio',
+				action: 'error',
+				duration: 120,
+				progress: 15,
+				error: {
+					code: error.code,
+					message: error.message,
+					currentTime: 18,
+					src: undefined
+				},
+				contentId
+			});
+		});
 	});
 
 	describe('progress event', () => {

--- a/test/tracking.test.js
+++ b/test/tracking.test.js
@@ -30,6 +30,7 @@ describe('Tracking' , () => {
 					action: eventName,
 					duration: 120,
 					progress: 0,
+					error: undefined,
 					contentId
 				});
 			})
@@ -52,6 +53,7 @@ describe('Tracking' , () => {
 					action: 'seeked',
 					duration: 120,
 					progress: 0,
+					error: undefined,
 					contentId
 				});
 			} catch(err) {
@@ -73,6 +75,7 @@ describe('Tracking' , () => {
 				action: 'playing',
 				duration: 120,
 				progress: 15,
+				error: undefined,
 				contentId
 			});
 		});
@@ -92,6 +95,7 @@ describe('Tracking' , () => {
 				action: 'playing',
 				duration: 120,
 				progress: 15,
+				error: undefined,
 				contentId
 			});
 		});
@@ -117,6 +121,7 @@ describe('Tracking' , () => {
 					action: 'progress',
 					duration: 120,
 					progress:  progressPoint,
+					error: undefined,
 					contentId
 				});
 			});
@@ -154,6 +159,7 @@ describe('Tracking' , () => {
 				action: 'progress',
 				duration: 120,
 				progress: 50,
+				error: undefined,
 				contentId
 			});
 		});
@@ -190,6 +196,7 @@ describe('Tracking' , () => {
 			duration: 120,
 			amount: 18,
 			amountPercentage:15,
+			error: undefined,
 			contentId
 		});
 	});


### PR DESCRIPTION
When errors occurred while handling media in HTMLMediaElement, a [MediaError object](https://developer.mozilla.org/en-US/docs/Web/API/MediaError) (which has `code` and `message` props) is attached to the element.
 For error investigation via Splunk, We are going to add the error object in tracking detail.