### PR TITLE
Tracking updates

### DIFF
--- a/analytics.md
+++ b/analytics.md
@@ -17,25 +17,36 @@ Each event has the following additional properties:
 detail: {
   category: 'audio',
   action: ev.type,
-  progress: 88, // current time / length (percentage)
-  duration: 14, // audio length in seconds
-  // optional properties
-  contentId: 'url-of-audio-file', 
-  playerType: '[inline|inline-multiplelines|block]',
-  audioSubtype: 'podcast'
+  audioSubtype: '[podcast|amy]',
+  // current time / length (percentage)
+  progress: 88,
+   // audio length in seconds
+  duration: 14,
+  // The content id of the audio being played
+  contentId: '{uuid}',
+  // The content id of the article in which the audio is embedded
+  rootContentId: '{uuid}',
+  // A string to identify which player is being used.
+  playerType: 'ft-audio-player',
+  // The the value of root ID when audio playback started.
+  root_id: '{event_root_id}'
 }
 ```
-There is also a `listened` event which contains how much (in seconds) of the audio was actually played. This event is fired on page `unload` or when the component is destroyed (as it the case in the app).
 
-```js
-detail: {
-  category: 'audio',
-  action: 'listened',
-  amount: 83.47, // amount of the audio actually listened to, in seconds
-  amountPercentage: 71.96 // as percentage of the total length of the audio, could be > 100
-  // optional properties
-  contentId: 'url-of-audio-file', 
-  playerType: '[inline|inline-multiplelines|block]',
-  audioSubtype: 'podcast'
-}
-```
+##
+
+Each audio event is inserted into the `Audio` table in redshift, which in turn powers the audio dashboard in chartio. Before an audio event is inserted, it passes through a number of systems which ensure the event contains all the data required for reporting. A simplification of [the architecture](https://sites.google.com/ft.com/data/documentation/spoor-stream-processor) is documented below.
+
+
+![](https://user-images.githubusercontent.com/616321/63938362-82b1c080-ca5c-11e9-8eb9-e252b6b9e5e2.png)
+
+
+| System/module  | Responsibility | Owned by | Useful reference |
+| ------------- | ------------- | ------------- |  ------------- |
+| o-audio  | Publishes audio event  | Customer Products | - |
+| spoor-enrichment  | Enriches event with data about the audio (title etc.)  | Customer Products | [transforms/audio.js](https://github.com/Financial-Times/spoor-enrichment/blob/master/server/transforms/audio.js)
+| spoor-stream-processor  | Maps fields in the event to columns in the audio table  | Data Platform | [mappings.json](https://github.com/Financial-Times/data-spoor-stream-processor/blob/master/config/mappings.json)
+| Audio table  | Stores the audio event  | Data Platform | - |
+| Bigquery/chartio  | Reporting on audio consumption  | Business Intelligence | [Audio dashboard](https://chartio.com/financialtimes/dashboard/356574/link_sharing/4847c824f70e33da577105929b98a7f6f6d0a887ce4bb697a99517febcf19fcb/) |
+
+

--- a/demos/src/native.mustache
+++ b/demos/src/native.mustache
@@ -2,7 +2,7 @@
 	<audio
 		controls
 		data-o-component="o-audio"
-		data-dispatch-listened-event-on-unload>
+		data-root-content-id="abc-123">
 		<source
 			src="https://media.acast.com/ftnewsbriefing/wednesday-november14/media.mp3"
 			type="audio/mpeg" />

--- a/src/js/o-audio.js
+++ b/src/js/o-audio.js
@@ -1,21 +1,5 @@
 import Tracking from './tracking';
 
-const UNLOAD_EVENTS = ['beforeunload', 'unload', 'pagehide'];
-
-function bindToUnloadEvents () {
-	UNLOAD_EVENTS.forEach(evtName => {
-		window.addEventListener(
-			evtName,
-			() => {
-				if (!this.hasDispatchedListened) {
-					this.hasDispatchedListened = true;
-					this.tracking.dispatchListenedEvent();
-				}
-			}
-		);
-	});
-}
-
 class OAudio {
 	/**
 	 * Class constructor.
@@ -32,18 +16,13 @@ class OAudio {
 		}, opts || OAudio.getDataAttributes(oAudioEl));
 
 		this.tracking = new Tracking(oAudioEl, this.options);
-		this.hasDispatchedListened = false;
 
-		if (this.options.dispatchListenedEventOnUnload !== undefined) {
-			bindToUnloadEvents.call(this);
-		}
 	}
 
 	/**
 	 * Destroy this component. Unbinds listeners and dispatches any final tracking events
 	 */
 	destroy() {
-		this.tracking.dispatchListenedEvent();
 		this.tracking.destroy();
 	}
 

--- a/src/js/tracking.js
+++ b/src/js/tracking.js
@@ -1,4 +1,3 @@
-/* eslint class-methods-use-this: ["error", { "exceptMethods": ["dispatchListenedEvent"] }] */
 import Delegate from 'ftdomdelegate';
 import * as Utils from 'o-utils';
 
@@ -127,10 +126,6 @@ class AudioTracking {
 			// log as 'progress' to keep consistency with o-video
 			fireEvent('progress', this, { progress: progressPoint });
 		}
-	}
-
-	dispatchListenedEvent () {
-		console.log('The "listened" event has been deprecated');
 	}
 
 	destroy() {

--- a/src/js/tracking.js
+++ b/src/js/tracking.js
@@ -64,7 +64,7 @@ const TRACKING_ATTRIBUTES = [
 	// The audio subtype ie. podcast, amy
 	'audioSubtype',
 
-	// A string to identify which player is being used. 
+	// A string to identify which player is being used.
 	// i.e. ft-audio-player
 	'playerType',
 
@@ -91,13 +91,9 @@ class AudioTracking {
 		this.trackingProperties = whitelistProps(trackingProperties);
 		this.audioLength = undefined;
 		this.lastTrackedProgressPoint = undefined;
-		this.amountListened = 0;
-		this.dateTimePlayStart = undefined;
 
 		this.delegate = new Delegate(audio);
 		this.delegate.on('loadedmetadata', this.extractMetadata.bind(this));
-		this.delegate.on('playing', this.startListeningTimer.bind(this));
-		this.delegate.on('pause', this.stopListeningTimer.bind(this));
 
 		this.attachListeners();
 		this.extractMetadata();
@@ -130,28 +126,6 @@ class AudioTracking {
 			// log as 'progress' to keep consistency with o-video
 			fireEvent('progress', this, { progress: progressPoint });
 		}
-	}
-
-	startListeningTimer () {
-		if (this.dateTimePlayStart === undefined) {
-			this.dateTimePlayStart = Date.now();
-		}
-	}
-
-	stopListeningTimer() {
-		if (this.dateTimePlayStart !== undefined) {
-			this.amountListened += Date.now() - this.dateTimePlayStart;
-			this.dateTimePlayStart = undefined;
-		}
-	}
-
-	dispatchListenedEvent() {
-		this.stopListeningTimer();
-		const amount = this.amountListened / 1000;
-		fireEvent('listened', this, {
-			amount: Number(amount.toFixed(2)),
-			amountPercentage: Number((amount / this.audioLength * 100).toFixed(2)),
-		});
 	}
 
 	destroy() {

--- a/src/js/tracking.js
+++ b/src/js/tracking.js
@@ -1,3 +1,4 @@
+/* eslint class-methods-use-this: ["error", { "exceptMethods": ["dispatchListenedEvent"] }] */
 import Delegate from 'ftdomdelegate';
 import * as Utils from 'o-utils';
 
@@ -126,6 +127,10 @@ class AudioTracking {
 			// log as 'progress' to keep consistency with o-video
 			fireEvent('progress', this, { progress: progressPoint });
 		}
+	}
+
+	dispatchListenedEvent () {
+		console.log('The "listened" event has been deprecated');
 	}
 
 	destroy() {

--- a/src/js/tracking.js
+++ b/src/js/tracking.js
@@ -109,7 +109,7 @@ class AudioTracking {
 		}
 
 		const progressPoint = getProgressPoint(progress);
-		if (progressPoint && progressPoint !== this.lastTrackedProgressPoint && !this.audio.paused) {
+		if (progressPoint !== this.lastTrackedProgressPoint && !this.audio.paused) {
 			this.lastTrackedProgressPoint = progressPoint;
 			// log as 'progress' to keep consistency with o-video
 			fireEvent('progress', this, { progress: progressPoint });

--- a/src/js/tracking.js
+++ b/src/js/tracking.js
@@ -28,15 +28,17 @@ const progressWindows = [
 	[73, 77, 75],
 	[83, 87, 85],
 	[88, 92, 90],
-	[93, 97, 95],
-	[100, 100, 100]
+	[93, 97, 95]
 ];
 
 function getProgressPoint(progress) {
+	if (progress === 0 || progress === 100) {
+		return progress;
+	}
 	// eslint-disable-next-line no-unused-vars
 	const [lower, upper, point] = progressWindows.find(([lower, upper]) => {
 		return progress >= lower && progress <= upper;
-	}) || [0, 0, 0];
+	}) || [];
 
 	return point;
 }
@@ -109,7 +111,7 @@ class AudioTracking {
 		}
 
 		const progressPoint = getProgressPoint(progress);
-		if (progressPoint !== this.lastTrackedProgressPoint && !this.audio.paused) {
+		if (progressPoint !== undefined && progressPoint !== this.lastTrackedProgressPoint && !this.audio.paused) {
 			this.lastTrackedProgressPoint = progressPoint;
 			// log as 'progress' to keep consistency with o-video
 			fireEvent('progress', this, { progress: progressPoint });

--- a/src/js/tracking.js
+++ b/src/js/tracking.js
@@ -54,9 +54,23 @@ const EVENTS = [
 ];
 
 const TRACKING_ATTRIBUTES = [
+	// The content id of the audio being played
 	'contentId',
+
+	// The content id of the article in which the audio is embedded
+	// Note: This can be the same as contentId
+	'rootContentId',
+
+	// The audio subtype ie. podcast, amy
 	'audioSubtype',
+
+	// A string to identify which player is being used. 
+	// i.e. ft-audio-player
 	'playerType',
+
+	// The the value of root ID when audio playback started.
+	// Required for the persistent player in the app so
+	// audio events can be linked back to the correct page:view event
 	'root_id',
 ];
 

--- a/src/js/tracking.js
+++ b/src/js/tracking.js
@@ -29,13 +29,13 @@ const progressWindows = [
 	[83, 87, 85],
 	[88, 92, 90],
 	[93, 97, 95],
-	[98, 100, 100]
+	[100, 100, 100]
 ];
 
 function getProgressPoint(progress) {
 	// eslint-disable-next-line no-unused-vars
 	const [lower, upper, point] = progressWindows.find(([lower, upper]) => {
-		return progress >= lower && progress < upper;
+		return progress >= lower && progress <= upper;
 	}) || [0, 0, 0];
 
 	return point;

--- a/test/oAudio.test.js
+++ b/test/oAudio.test.js
@@ -2,7 +2,6 @@
 import proclaim from 'proclaim';
 import sinon from 'sinon/pkg/sinon';
 import * as fixtures from './helpers/fixtures';
-import OTrackingCollector from './helpers/o-tracking-collector';
 
 import OAudio from './../main';
 
@@ -48,56 +47,6 @@ describe("OAudio", () => {
 		it("single component when initialized with a root element", () => {
 			const boilerplate = OAudio.init('#element');
 			proclaim.equal(boilerplate instanceof OAudio, true);
-		});
-	});
-
-	describe('tracking listening time', () => {
-		const oTracking = new OTrackingCollector();
-		const stubAudioEl = new EventTarget();
-		let _onbeforeunload;
-		before(() => {
-			_onbeforeunload = window.onbeforeunload;
-			window.onbeforeunload = f => f;
-		});
-		after(() => {
-			oTracking.stop();
-			window.onbeforeunload = _onbeforeunload;
-		});
-
-		it('when the component is destroyed', () => {
-			const events = oTracking.start();
-
-			const audio = new OAudio(stubAudioEl);
-			audio.destroy();
-
-			proclaim.lengthEquals(events, 1);
-			const { action } = events[0];
-			proclaim.equal(action, "listened");
-		});
-
-
-		['beforeunload', 'unload', 'pagehide'].forEach(eventName => {
-			it(`when the page unloads via ${eventName}`, () => {
-				const events = oTracking.start();
-				new OAudio(stubAudioEl, {
-					dispatchListenedEventOnUnload: true
-				});
-
-				window.dispatchEvent(new Event(eventName, { cancelable: true }));
-				proclaim.lengthEquals(events, 1);
-				const { action } = events[0];
-				proclaim.equal(action, "listened");
-			});
-		});
-
-		it('only dispatches listened event once', () => {
-			const events = oTracking.start();
-			new OAudio(stubAudioEl, {
-				dispatchListenedEventOnUnload: true
-			});
-			window.dispatchEvent(new Event('unload'));
-			window.dispatchEvent(new Event('pagehide'));
-			proclaim.lengthEquals(events, 1);
 		});
 	});
 

--- a/test/tracking.test.js
+++ b/test/tracking.test.js
@@ -161,6 +161,7 @@ describe('Tracking' , () => {
 
 
 		it('only emits a progress event when the current time is a known progress point', () => {
+			// eslint-disable-next-line no-unused-vars
 			const [progressAt0, ...events] = oTracking.start();
 			const stubAudioEl = initAudioElement();
 			initTracking(stubAudioEl, { contentId });

--- a/test/tracking.test.js
+++ b/test/tracking.test.js
@@ -249,7 +249,8 @@ describe('Tracking' , () => {
 		[
 			[ 'contentId', 'abc-123' ],
 			[ 'audioSubtype', 'podcast' ],
-			[ 'playerType', 'inline' ]
+			[ 'playerType', 'inline' ],
+			[ 'rootContentId', 'def-456' ]
 
 		].map(([ propName, propValue ]) =>
 			it(`includes ${propName} in the event detail`, () => {

--- a/test/tracking.test.js
+++ b/test/tracking.test.js
@@ -209,30 +209,6 @@ describe('Tracking' , () => {
 		});
 	});
 
-	it('dispatches listened event with total amount listened', () => {
-		const events = oTracking.start();
-		const clock = sinon.useFakeTimers();
-		const stubAudioEl = initAudioElement();
-		const tracking = initTracking(stubAudioEl, { contentId });
-
-		stubAudioEl.dispatchEvent(new Event('playing'));
-		clock.tick(18000); // pretend 18s have passed by
-		stubAudioEl.dispatchEvent(new Event('pause'));
-
-		tracking.dispatchListenedEvent();
-		clock.restore();
-
-		proclaim.deepEqual(events[2], {
-			category: 'audio',
-			action: 'listened',
-			duration: 120,
-			amount: 18,
-			amountPercentage:15,
-			error: undefined,
-			contentId
-		});
-	});
-
 	it('removes event listeners when o-audio element is destroyed', () => {
 		const events = oTracking.start();
 		const stubAudioEl = initAudioElement();

--- a/test/tracking.test.js
+++ b/test/tracking.test.js
@@ -139,7 +139,7 @@ describe('Tracking' , () => {
 			{ currentTime: 30, progressPoint: 25 },
 			{ currentTime: 61, progressPoint: 50 },
 			{ currentTime: 91, progressPoint: 75 },
-			{ currentTime: 119, progressPoint: 100 }
+			{ currentTime: 120, progressPoint: 100 }
 		].forEach(({ currentTime, progressPoint }) => {
 			it(`emits a progress event at ${progressPoint}%`, () => {
 				const events = oTracking.start();

--- a/test/tracking.test.js
+++ b/test/tracking.test.js
@@ -134,6 +134,7 @@ describe('Tracking' , () => {
 
 	describe('progress event', () => {
 		[
+			{ currentTime: 0, progressPoint: 0 },
 			{ currentTime: 10, progressPoint: 10 },
 			{ currentTime: 30, progressPoint: 25 },
 			{ currentTime: 61, progressPoint: 50 },
@@ -160,14 +161,13 @@ describe('Tracking' , () => {
 
 
 		it('only emits a progress event when the current time is a known progress point', () => {
-			const events = oTracking.start();
+			const [progressAt0, ...events] = oTracking.start();
 			const stubAudioEl = initAudioElement();
 			initTracking(stubAudioEl, { contentId });
 
 			// trigger timeupdate event at 15%
 			stubAudioEl.currentTime = 18;
 			stubAudioEl.dispatchEvent(new Event('timeupdate'));
-
 			proclaim.lengthEquals(events, 0);
 		});
 


### PR DESCRIPTION
- Removes `listened` event as this is no longer needed for reporting - **breaking change**
- Updates the `progress` event to fire at `0%`
- Provides further documentation on how audio events are used
