### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
-import oAudio from './src/js/o-audio';
-import Tracking from './src/js/tracking';
+import oAudio from './src/js/o-audio.js';
+import Tracking from './src/js/tracking.js';
 
 const constructAll = function () {
 	oAudio.init();

--- a/src/js/o-audio.js
+++ b/src/js/o-audio.js
@@ -1,4 +1,4 @@
-import Tracking from './tracking';
+import Tracking from './tracking.js';
 
 class OAudio {
 	/**

--- a/test/oAudio.test.js
+++ b/test/oAudio.test.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
-import * as fixtures from './helpers/fixtures';
+import * as fixtures from './helpers/fixtures.js';
 
-import OAudio from './../main';
+import OAudio from './../main.js';
 
 describe("OAudio", () => {
 	it('is defined', () => {

--- a/test/tracking.test.js
+++ b/test/tracking.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
-import Tracking from './../src/js/tracking';
-import OTrackingCollector from './helpers/o-tracking-collector';
+import Tracking from './../src/js/tracking.js';
+import OTrackingCollector from './helpers/o-tracking-collector.js';
 
 
 const contentId = 'abc-123';


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing