### PR TITLE
Make getDataAttributes ignore data attributes which are not in the component's namespace

### DIFF
--- a/src/js/o-audio.js
+++ b/src/js/o-audio.js
@@ -40,8 +40,8 @@ class OAudio {
 		}
 		return Object.keys(oAudioEl.dataset).reduce((options, key) => {
 
-			// Ignore data-o-component
-			if (key === 'oComponent') {
+			// Ignore keys which are not in the component's namespace
+			if (!key.match(/^oAudio(\w)(\w+)$/)) {
 				return options;
 			}
 


### PR DESCRIPTION
This keeps the method aligned with the definition in the component template https://github.com/Financial-Times/create-origami-component/pull/214